### PR TITLE
fix unilink be intercepted

### DIFF
--- a/ios/Classes/SwiftFlutterCoreSpotlightPlugin.swift
+++ b/ios/Classes/SwiftFlutterCoreSpotlightPlugin.swift
@@ -72,6 +72,6 @@ public class SwiftFlutterCoreSpotlightPlugin: NSObject, FlutterPlugin {
                               "userInfo": userActivity.userInfo
                             ])
     }
-    return true
+    return false
   }
 }


### PR DESCRIPTION
Third-party login plug such as wechat need to call back unilink 

The [FlutterPluginAppLifeDelegate code](https://github.com/flutter/engine/blob/e700c45464ce21a5cadb2f519abd463143538a52/shell/platform/darwin/ios/framework/Source/FlutterPluginAppLifeCycleDelegate.mm#L425)  tells us that returning true will be intercepted, so if you want other plug-ins to continue using UniLink, you should return false.
