### PR TITLE
fix indexing on iOS 17

### DIFF
--- a/ios/Classes/SwiftFlutterCoreSpotlightPlugin.swift
+++ b/ios/Classes/SwiftFlutterCoreSpotlightPlugin.swift
@@ -25,6 +25,7 @@ public class SwiftFlutterCoreSpotlightPlugin: NSObject, FlutterPlugin {
       let searchableItems = arguments.map { itemMap -> CSSearchableItem in
         let attributeSet = CSSearchableItemAttributeSet(itemContentType: kUTTypeText as String)
         attributeSet.title = itemMap["attributeTitle"] as? String
+        attributeSet.displayName = itemMap["attributeTitle"] as? String
         attributeSet.contentDescription = itemMap["attributeDescription"] as? String
         
         let item = CSSearchableItem(uniqueIdentifier: "\(itemMap["uniqueIdentifier"] as? String ?? "")",


### PR DESCRIPTION
It is required to set the `displayName` of `CSSearchableItemAttributeSet ` as described here https://developer.apple.com/forums/thread/734996.